### PR TITLE
ignore additional fields not included in TreeModel

### DIFF
--- a/src/main/kotlin/sh/hsp/techtree/TreeModel.kt
+++ b/src/main/kotlin/sh/hsp/techtree/TreeModel.kt
@@ -1,10 +1,14 @@
 package sh.hsp.techtree
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+
 typealias ID = String
+@JsonIgnoreProperties(ignoreUnknown = true)
 data class TreeModel(
     val nodes: List<TreeNode>
 )
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 data class TreeNode(
     val title: ID,
     val requires: List<ID>? = null

--- a/src/test/resources/example.yaml
+++ b/src/test/resources/example.yaml
@@ -5,3 +5,5 @@ nodes:
       - "tygrys"
   - title: "kot"
   - title: "tygrys"
+    additional_field_not_meant_to_be_in_yaml_file: "shell"
+additional_field_not_meant_to_be_in_yaml: "void"


### PR DESCRIPTION
It should allow such yaml to be parsed correctly:
```
nodes:
  - title: "miau"
    requires:
      - "kot"
      - "tygrys"
  - title: "kot"
  - title: "tygrys"
    additional_field_not_meant_to_be_in_yaml_file: "shell"
additional_field_not_meant_to_be_in_yaml: "void"
```
but it will still fail when yaml is made as such:
```
nodes:
  - title: "miau"
    requires:
      - "kot"
      - "tygrys"
  - title: "kot"
  - title: "tygrys"
  - additional_field_not_meant_to_be_in_yaml_file: "shell"
```